### PR TITLE
Fixed build issues on new kernels were `rdtscll` has been deprecated.

### DIFF
--- a/driver/linux/crystalhd_misc.h
+++ b/driver/linux/crystalhd_misc.h
@@ -41,6 +41,11 @@
 /* forward declare */
 struct crystalhd_hw;
 
+/* Fix build issue with latest kernels */
+#ifndef rdtscll
+#define rdtscll(now)    do { (now) = rdtsc_ordered(); } while (0)
+#endif
+
 /* Global element pool for all Queue management.
  * TX: Active = BC_TX_LIST_CNT, Free = BC_TX_LIST_CNT.
  * RX: Free = BC_RX_LIST_CNT, Active = 2


### PR DESCRIPTION
Needed the driver to build on Debian with Linux kernel version 4.19.12-1
`rdtscll` seems to have been recently deprecated and removed so I made a quick fix.